### PR TITLE
fix(utils): remove debug messages from session names

### DIFF
--- a/functions/utils.sh
+++ b/functions/utils.sh
@@ -100,11 +100,10 @@ function get_session_name() {
   local final_path
 
   leaf_path=$(basename "$1")
-  echo "arg=$1"
 
   ifs=$IFS
   IFS='/'
-  read -ra all_dirs <<< "$1"
+  read -ra all_dirs <<< "${1:1}"
   IFS="$ifs"
   unset "all_dirs[${#all_dirs[@]}-1]"
 
@@ -113,7 +112,6 @@ function get_session_name() {
   if (( ${#all_dirs[@]} >= 1 )); then
     for dir in "${all_dirs[@]}"
     do
-    echo "dir=$dir"
       if [[ "${dir:0:1}" != "." ]]; then
         final_path="$final_path/${dir:0:1}"
       else

--- a/tests/functions/util.bats
+++ b/tests/functions/util.bats
@@ -58,7 +58,7 @@ setup() {
 
   run get_session_name "$directory_path"
 
-  assert_output --partial "$expected_session_name"
+  assert_output --regexp "^${expected_session_name}-"
 }
 
 @test "session names with leading dots resolve correctly" {
@@ -67,7 +67,7 @@ setup() {
 
   run get_session_name "$directory_path"
 
-  assert_output --partial "$expected_session_name"
+  assert_output --regexp "^${expected_session_name}-"
 }
 
 @test "session names with trailing dots resolve correctly" {
@@ -76,7 +76,7 @@ setup() {
 
   run get_session_name "$directory_path"
 
-  assert_output --partial "$expected_session_name"
+  assert_output --regexp "^${expected_session_name}-"
 }
 
 @test "session names with dots in the middle resolve correctly" {
@@ -85,5 +85,5 @@ setup() {
 
   run get_session_name "$directory_path"
 
-  assert_output --partial "$expected_session_name"
+  assert_output --regexp "^${expected_session_name}-"
 }


### PR DESCRIPTION
Debug messages were kept in the functions responsible for generating session names, resulting in very strange session names being generated when creating new tmux sessions. This commit removes the debug messages, and changes the corresponding unit tests to use regular expressions in favor of partial matching for session names, ensuring that this issue does not happen again in the future.