### PR TITLE
fix(workflows): fix local shellcheck execution

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
+        with:
+          ignore_paths: ./bats/*
         env:
           SHELLCHECK_OPTS: -x
   test:


### PR DESCRIPTION
When executing "act" locally, the GitHub workflow fails if the bats submodule has been checked out. This is because the shellcheck execution includes the bats submodule in the sources to check, and apparently bats does not pass the shellcheck. Ignore the bats submodule when executing shellcheck so that the workflow passes also when executing locally.

Closes #14 